### PR TITLE
Update gcr.io/the-dash:42!

### DIFF
--- a/Dockerfile.gcrwithdashes
+++ b/Dockerfile.gcrwithdashes
@@ -1,3 +1,3 @@
-FROM gcr.io/the-dash:1
+FROM gcr.io/the-dash:42
 
 RUN echo "test"


### PR DESCRIPTION
`gcr.io/the-dash` changed recently. This pull request ensures you're using the latest version of the image and changes `gcr.io/the-dash` to the latest tag: `42`

New base image: `gcr.io/the-dash:42`