### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/Dockerfile.verydashingdomainwithdashypath
+++ b/Dockerfile.verydashingdomainwithdashypath
@@ -1,3 +1,3 @@
-FROM this-registry-has-dashes.some-company.with-dashes.io/some-path/with-more-dashes/rv-python-runtime:1.0.0
+FROM this-registry-has-dashes.some-company.with-dashes.io/some-path/with-more-dashes/rv-python-runtime:42
 
 RUN echo "hello world"


### PR DESCRIPTION
`this-registry-has-dashes.some-company.with-dashes.io/some-path/with-more-dashes/rv-python-runtime` changed recently. This pull request ensures you're using the latest version of the image and changes `this-registry-has-dashes.some-company.with-dashes.io/some-path/with-more-dashes/rv-python-runtime` to the latest tag: `42`

New base image: `this-registry-has-dashes.some-company.with-dashes.io/some-path/with-more-dashes/rv-python-runtime:42`