### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/Dockerfile.gcrslashnormalslashdash
+++ b/Dockerfile.gcrslashnormalslashdash
@@ -1,3 +1,3 @@
-FROM gcr.io/thedash/the-mash:1
+FROM gcr.io/thedash/the-mash:42
 
 RUN echo "test"


### PR DESCRIPTION
`gcr.io/thedash/the-mash` changed recently. This pull request ensures you're using the latest version of the image and changes `gcr.io/thedash/the-mash` to the latest tag: `42`

New base image: `gcr.io/thedash/the-mash:42`