### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/Dockerfile.dashingdomains
+++ b/Dockerfile.dashingdomains
@@ -1,4 +1,4 @@
-FROM this-registry-has-dashes.somecompany.io/rv-python-runtime:1.0.0 AS build
+FROM this-registry-has-dashes.somecompany.io/rv-python-runtime:42 AS build
 
 FROM this-registry-has-dashes.some-company.with-dashes.io/rv-python-runtime:1.0.0
 


### PR DESCRIPTION
`this-registry-has-dashes.somecompany.io/rv-python-runtime` changed recently. This pull request ensures you're using the latest version of the image and changes `this-registry-has-dashes.somecompany.io/rv-python-runtime` to the latest tag: `42`

New base image: `this-registry-has-dashes.somecompany.io/rv-python-runtime:42`