### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/Dockerfile.dashing-with-dotted-image-name
+++ b/Dockerfile.dashing-with-dotted-image-name
@@ -1,3 +1,3 @@
-FROM this-registry-has-dashes.some-company.with-dashes.io/some-path/with-more-dashes/rv-python-3.7-runtime:1.0.0
+FROM this-registry-has-dashes.some-company.with-dashes.io/some-path/with-more-dashes/rv-python-3.7-runtime:1.0.1
 
 RUN echo "hello world"


### PR DESCRIPTION
`this-registry-has-dashes.some-company.with-dashes.io/some-path/with-more-dashes/rv-python-3.7-runtime` changed recently. This pull request ensures you're using the latest version of the image and changes `this-registry-has-dashes.some-company.with-dashes.io/some-path/with-more-dashes/rv-python-3.7-runtime` to the latest tag: `1.0.1`

New base image: `this-registry-has-dashes.some-company.with-dashes.io/some-path/with-more-dashes/rv-python-3.7-runtime:1.0.1`